### PR TITLE
Port to Qt >= 5.15 and install package config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,34 @@ cmake_minimum_required(VERSION 3.12)
 
 project(PowerSlider)
 
-option(BUILD_DESIGNER_PLUNGIN "Build Qt Designer Plugin" ON)
+option(BUILD_DESIGNER_PLUGIN "Build Qt Designer Plugin" ON)
 option(BUILD_EXAMPLE_APP "Build example app" ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
+#
+# Qt5 and Qt6 can be retrieved using versionless targets introduced in Qt5.15:
+# https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#versionless-targets
+macro(find_qt_package)
+    set(options REQUIRED)
+    set(oneValueArgs "")
+    set(multiValueArgs COMPONENTS)
+
+    cmake_parse_arguments(MY_OPTIONS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT MY_OPTIONS_COMPONENTS) # User didn't enter any component
+        set(MY_OPTIONS_COMPONENTS "")
+    endif()
+
+    find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} QUIET)
+    if(NOT Qt6_FOUND)
+        if(${MY_OPTIONS_REQUIRED})
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} REQUIRED)
+        else()
+            find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS})
+        endif()
+    endif()
+endmacro()
+
+find_qt_package(COMPONENTS Core Widgets REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -14,18 +38,22 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-set(BUNDLE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Bundle-${CMAKE_CXX_COMPILER_ID})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BUNDLE_DIRECTORY}/${CMAKE_BUILD_TYPE}/bin)
-set(EXECUTABLE_OUTPUT_PATH         ${BUNDLE_DIRECTORY}/${CMAKE_BUILD_TYPE}/bin)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${BUNDLE_DIRECTORY}/${CMAKE_BUILD_TYPE}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BUNDLE_DIRECTORY}/${CMAKE_BUILD_TYPE}/lib)
+set(BUNDLE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Bundle-${CMAKE_CXX_COMPILER_ID}-${CMAKE_BUILD_TYPE}")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX
+        "${BUNDLE_DIRECTORY}"
+        CACHE PATH "Install path prefix, prepended onto install directories." FORCE
+        )
+    message("Set install prefix to ${CMAKE_INSTALL_PREFIX}")
+endif()
+include(GNUInstallDirs)
 
 set(lib_SOURCES
     ./src/PowerSlider.cpp
     )
 
 add_library(PowerSlider SHARED ${lib_SOURCES} )
-target_link_libraries(PowerSlider Qt5::Widgets )
+target_link_libraries(PowerSlider Qt::Widgets )
 
 if(BUILD_DESIGNER_PLUNGIN)
     target_compile_definitions(PowerSlider PRIVATE "POWERSLIDER_DESIGNER_PLUGIN")
@@ -37,14 +65,14 @@ install(DIRECTORY src/ DESTINATION include/PowerSlider
 
 
 if(BUILD_DESIGNER_PLUNGIN)
-    find_package(Qt5 REQUIRED COMPONENTS Core Widgets UiTools)
+    find_qt_package( COMPONENTS Core Widgets UiTools REQUIRED)
     set(plugin_SOURCES
         ./src/PowerSlider.cpp 
         ./src/PowerSliderPlugin.cpp
         )
     
     add_library(PowerSliderPlugin SHARED  ${plugin_SOURCES})
-    target_link_libraries(PowerSliderPlugin Qt5::UiTools Qt5::Widgets )
+    target_link_libraries(PowerSliderPlugin Qt::UiTools Qt::Widgets )
     
     install(TARGETS PowerSliderPlugin DESTINATION plugins/designer)
 endif(BUILD_DESIGNER_PLUNGIN)
@@ -55,6 +83,6 @@ if(BUILD_EXAMPLE_APP)
         ./src/PowerSlider.cpp)
     
     add_executable(example  ${example_SOURCES})
-    target_link_libraries(example Qt5::Widgets )
+    target_link_libraries(example Qt::Widgets )
     target_include_directories(example PUBLIC  ${CMAKE_SOURCE_DIR})
 endif(BUILD_EXAMPLE_APP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,43 +46,79 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         )
     message("Set install prefix to ${CMAKE_INSTALL_PREFIX}")
 endif()
-include(GNUInstallDirs)
 
 set(lib_SOURCES
     ./src/PowerSlider.cpp
     )
 
-add_library(PowerSlider SHARED ${lib_SOURCES} )
-target_link_libraries(PowerSlider Qt::Widgets )
+add_library(${PROJECT_NAME} SHARED ${lib_SOURCES} )
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-if(BUILD_DESIGNER_PLUNGIN)
-    target_compile_definitions(PowerSlider PRIVATE "POWERSLIDER_DESIGNER_PLUGIN")
-endif()
+target_link_libraries(${PROJECT_NAME} Qt::Widgets )
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER src/PowerSlider.hpp)
+target_include_directories(
+    ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
 
-install(TARGETS PowerSlider DESTINATION lib)
-install(DIRECTORY src/ DESTINATION include/PowerSlider
-    FILES_MATCHING PATTERN "*.hpp")
+if(BUILD_DESIGNER_PLUGIN)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "POWERSLIDER_DESIGNER_PLUGIN")
 
-
-if(BUILD_DESIGNER_PLUNGIN)
     find_qt_package( COMPONENTS Core Widgets UiTools REQUIRED)
     set(plugin_SOURCES
         ./src/PowerSlider.cpp 
         ./src/PowerSliderPlugin.cpp
         )
     
-    add_library(PowerSliderPlugin SHARED  ${plugin_SOURCES})
-    target_link_libraries(PowerSliderPlugin Qt::UiTools Qt::Widgets )
-    
-    install(TARGETS PowerSliderPlugin DESTINATION plugins/designer)
-endif(BUILD_DESIGNER_PLUNGIN)
+    add_library(${PROJECT_NAME}Plugin SHARED  ${plugin_SOURCES})
+    target_link_libraries(${PROJECT_NAME}Plugin Qt::UiTools Qt::Widgets )
+endif(BUILD_DESIGNER_PLUGIN)
 
+# manage installation
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# configure the package config file
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake @ONLY
+)
+
+# export targets file in buildtree and install targets file and package config file
+export(TARGETS ${PROJECT_NAME}
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
+    )
+install(EXPORT ${PROJECT_NAME}Targets NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+
+# install target
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    CONFIGURATIONS ${CMAKE_BUILD_TYPE}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+    )
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(MSVC OR MSVC_IDE)
+        install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+endif()
+
+if(BUILD_DESIGNER_PLUGIN)
+    install(TARGETS ${PROJECT_NAME}Plugin DESTINATION plugins/designer)
+endif(BUILD_DESIGNER_PLUGIN)
+
+# manage example
 if(BUILD_EXAMPLE_APP)
-    set(example_SOURCES
-        ./example/main.cpp
-        ./src/PowerSlider.cpp)
-    
-    add_executable(example  ${example_SOURCES})
-    target_link_libraries(example Qt::Widgets )
-    target_include_directories(example PUBLIC  ${CMAKE_SOURCE_DIR})
+    # find_package will find PowerSlider package config in the buildtree
+    list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR})
+    add_subdirectory(example)
 endif(BUILD_EXAMPLE_APP)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,30 @@
+include(FindPackageHandleStandardArgs)
+set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG ${CMAKE_CURRENT_LIST_FILE})
+find_package_handle_standard_args(@PROJECT_NAME@ CONFIG_MODE)
+
+if(NOT TARGET @PROJECT_NAME@)
+    macro(find_qt_dependency)
+        set(options REQUIRED)
+        set(oneValueArgs "")
+        set(multiValueArgs COMPONENTS)
+
+        cmake_parse_arguments(MY_OPTIONS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+        if(NOT MY_OPTIONS_COMPONENTS) # User didn't enter any component
+            set(MY_OPTIONS_COMPONENTS "")
+        endif()
+
+        find_package(Qt6 COMPONENTS ${MY_OPTIONS_COMPONENTS} QUIET)
+        if(NOT Qt6_FOUND)
+            if(${MY_OPTIONS_REQUIRED})
+                find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS} REQUIRED)
+            else()
+                find_package(Qt5 5.15 COMPONENTS ${MY_OPTIONS_COMPONENTS})
+            endif()
+        endif()
+    endmacro()
+
+    find_qt_dependency(COMPONENTS Core Widgets REQUIRED)
+
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(PowerSliderDemo)
+
+find_package(PowerSlider REQUIRED)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(demo_source
+    main.cpp
+ )
+    
+add_executable(${PROJECT_NAME}  ${demo_source})
+target_link_libraries(${PROJECT_NAME} PowerSlider::PowerSlider )

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,6 +1,6 @@
 #include <QtWidgets>
 
-#include "src/PowerSlider.hpp"
+#include "PowerSlider.hpp"
 
 int main( int argc, char* argv[] ) {
     QApplication app( argc, argv );

--- a/src/PowerSlider.cpp
+++ b/src/PowerSlider.cpp
@@ -43,7 +43,7 @@ PowerSlider::PowerSlider( QWidget* parent,
 
     // layout in a hbox
     QHBoxLayout* layout = new QHBoxLayout;
-    layout->setMargin( 0 );
+    layout->setContentsMargins( {} );
     layout->setSpacing( 6 );
     layout->addWidget( slider_ );
     layout->addWidget( spinBox_ );


### PR DESCRIPTION
 Code updated to Qt >= 5.15
  - find Qt package in a versionless maneer
  - fix some deprecated (and removed) method on widgets
  
Generates and install cmake package config file
  - client are able to do a find_package(PowerSlider) and link their target to PowerSlider::PowerSlider to access all the functionalities and dependencies
  - example app uses this to link against PowerSlider library, either after installation or from the same buildtree